### PR TITLE
Add CloudWatch Logs Insights Query Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,16 @@ This is useful for scenarios where you want to allow log viewing but prevent any
 | get_log_events    | READ           | Retrieve log events from a specified log stream    |
 | filter_log_events | READ           | Search log events with a pattern across log groups |
 
-For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloudwatch-logs/blob/main/TOOLS.md).
+### Insights Operations
 
-> **Note:** This project is under development. Additional CloudWatch Logs operations are planned for future releases.
+| Tool Name         | Operation Type | Description                                            |
+| ----------------- | -------------- | ------------------------------------------------------ |
+| start_query       | READ           | Start a CloudWatch Logs Insights query                 |
+| stop_query        | READ           | Stop a running CloudWatch Logs Insights query          |
+| get_query_results | READ           | Retrieve results from a CloudWatch Logs Insights query |
+| describe_queries  | READ           | List and describe CloudWatch Logs Insights queries     |
+
+For detailed documentation on each tool, including parameters and examples, see [TOOLS.md](https://github.com/hyorimitsu/mcp-amazon-cloudwatch-logs/blob/main/TOOLS.md).
 
 ## Development
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -412,3 +412,192 @@ Response:
   "nextToken": "eyJsb2dTdHJlYW1OYW1lIjoiaW5zdGFuY2UtNTY3OCIsImV2ZW50SWQiOiI5ODc2NTQzMjEwOTg3NjU0MzIxMDk4NzY1NDMyMTA5ODc2NTQzMjEwOTg3NjU0MzIxMDk4NzY1NCJ9"
 }
 ```
+
+### start_query [READ]
+
+Start a CloudWatch Logs Insights query.
+
+**Parameters:**
+
+- `queryLanguage` (string, optional): Specify the query language to use for this query
+- `logGroupName` (string, optional): The log group on which to perform the query
+- `logGroupNames` (array of strings, optional): The list of log groups to be queried
+- `logGroupIdentifiers` (array of strings, optional): The list of log groups to query
+- `startTime` (number, required): The beginning of the time range to query
+- `endTime` (number, required): The end of the time range to query
+- `queryString` (string, required): The query string to use
+- `limit` (number, optional): The maximum number of log events to return in the query
+
+**Example:**
+
+Request:
+
+```json
+{
+  "logGroupNames": ["my-application-logs"],
+  "startTime": 1617234567,
+  "endTime": 1617320967,
+  "queryString": "fields @timestamp, @message | filter @message like /ERROR/ | sort @timestamp desc"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "queryId": "11a11a11-1111-11a1-11a1-11a11a11a111"
+}
+```
+
+### stop_query [READ]
+
+Stop a running CloudWatch Logs Insights query.
+
+**Parameters:**
+
+- `queryId` (string, required): The ID number of the query to stop
+
+**Example:**
+
+Request:
+
+```json
+{
+  "queryId": "11a11a11-1111-11a1-11a1-11a11a11a111"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "success": true
+}
+```
+
+### get_query_results [READ]
+
+Retrieve results from a CloudWatch Logs Insights query.
+
+**Parameters:**
+
+- `queryId` (string, required): The ID number of the query
+
+**Example:**
+
+Request:
+
+```json
+{
+  "queryId": "11a11a11-1111-11a1-11a1-11a11a11a111"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "queryLanguage": "CWLI",
+  "results": [
+    [
+      {
+        "field": "@timestamp",
+        "value": "2023-04-01 12:34:56.789"
+      },
+      {
+        "field": "@message",
+        "value": "ERROR: Database connection failed"
+      }
+    ],
+    [
+      {
+        "field": "@timestamp",
+        "value": "2023-04-01 12:30:45.678"
+      },
+      {
+        "field": "@message",
+        "value": "ERROR: Authentication failed for user 'admin'"
+      }
+    ]
+  ],
+  "statistics": {
+    "recordsMatched": 2,
+    "recordsScanned": 1000,
+    "estimatedRecordsSkipped": 0,
+    "bytesScanned": 123456,
+    "estimatedBytesSkipped": 0,
+    "logGroupsScanned": 1
+  },
+  "status": "Complete"
+}
+```
+
+### describe_queries [READ]
+
+List and describe CloudWatch Logs Insights queries.
+
+**Parameters:**
+
+- `logGroupName` (string, optional): Limits the returned queries to only those for the specified log group
+- `status` (string, optional): Limits the returned queries to only those that have the specified status
+- `maxResults` (number, optional): Limits the number of returned queries to the specified number
+- `nextToken` (string, optional): The token for the next set of items to return
+
+**Example:**
+
+Request:
+
+```json
+{
+  "status": "Running"
+}
+```
+
+Response:
+
+```json
+{
+  "$metadata": {
+    "httpStatusCode": 200,
+    "requestId": "example-request-id",
+    "attempts": 1,
+    "totalRetryDelay": 0
+  },
+  "queries": [
+    {
+      "queryLanguage": "CWLI",
+      "queryId": "11a11a11-1111-11a1-11a1-11a11a11a111",
+      "queryString": "fields @timestamp, @message | filter @message like /ERROR/ | sort @timestamp desc",
+      "status": "Running",
+      "createTime": 1617234567000,
+      "logGroupName": "my-application-logs"
+    },
+    {
+      "queryLanguage": "CWLI",
+      "queryId": "22b22b22-2222-22b2-22b2-22b22b22b222",
+      "queryString": "fields @timestamp, @message | stats count() by bin(30s)",
+      "status": "Running",
+      "createTime": 1617234568000,
+      "logGroupName": "my-api-logs"
+    }
+  ]
+}
+```

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4,9 +4,40 @@ This document provides detailed information about the tools available in the Ama
 
 > **Note:** This project is currently under active development. The available tools and their interfaces may change before the first stable release.
 
+## Table of Contents
+
+### Log Group Operations
+
+- [create_log_group](#create_log_group-write) - Create a new log group
+- [describe_log_groups](#describe_log_groups-read) - List and describe log groups
+- [delete_log_group](#delete_log_group-write) - Delete a log group
+
+### Log Stream Operations
+
+- [create_log_stream](#create_log_stream-write) - Create a new log stream
+- [describe_log_streams](#describe_log_streams-read) - List and describe log streams
+- [delete_log_stream](#delete_log_stream-write) - Delete a log stream
+
+### Log Events Operations
+
+- [put_log_events](#put_log_events-write) - Write log events to a stream
+- [get_log_events](#get_log_events-read) - Retrieve log events from a stream
+- [filter_log_events](#filter_log_events-read) - Search log events with a pattern
+
+### Insights Operations
+
+- [start_query](#start_query-read) - Start a insights query
+- [stop_query](#stop_query-read) - Stop a running insights query
+- [get_query_results](#get_query_results-read) - Retrieve query results
+- [describe_queries](#describe_queries-read) - List and describe queries
+
 ## Available Tools
 
-### create_log_group [WRITE]
+### Log Group Operations
+
+Log Group Operations allow you to create, manage, and delete log groups in CloudWatch Logs. Log groups are containers for log streams that share the same retention, monitoring, and access control settings.
+
+#### create_log_group [WRITE]
 
 Creates a new Amazon CloudWatch Logs log group.
 
@@ -44,7 +75,7 @@ Response:
 }
 ```
 
-### describe_log_groups [READ]
+#### describe_log_groups [READ]
 
 List and describe Amazon CloudWatch Logs log groups.
 
@@ -93,7 +124,7 @@ Response:
 }
 ```
 
-### delete_log_group [WRITE]
+#### delete_log_group [WRITE]
 
 Delete an Amazon CloudWatch Logs log group.
 
@@ -124,7 +155,11 @@ Response:
 }
 ```
 
-### create_log_stream [WRITE]
+### Log Stream Operations
+
+Log Stream Operations allow you to create, manage, and delete log streams within log groups. Log streams represent different sources of logs in the same log group, such as application instances or components.
+
+#### create_log_stream [WRITE]
 
 Create a new log stream in an Amazon CloudWatch Logs log group.
 
@@ -157,7 +192,7 @@ Response:
 }
 ```
 
-### describe_log_streams [READ]
+#### describe_log_streams [READ]
 
 List and describe log streams in an Amazon CloudWatch Logs log group.
 
@@ -209,7 +244,7 @@ Response:
 }
 ```
 
-### delete_log_stream [WRITE]
+#### delete_log_stream [WRITE]
 
 Delete a log stream in an Amazon CloudWatch Logs log group.
 
@@ -242,7 +277,11 @@ Response:
 }
 ```
 
-### put_log_events [WRITE]
+### Log Events Operations
+
+Log Events Operations allow you to write, retrieve, and search log events within log streams. Log events are the actual log records containing timestamps and message data.
+
+#### put_log_events [WRITE]
 
 Write log events to a specified log stream in Amazon CloudWatch Logs.
 
@@ -294,7 +333,7 @@ Response:
 }
 ```
 
-### get_log_events [READ]
+#### get_log_events [READ]
 
 Retrieve log events from a specified log stream in Amazon CloudWatch Logs.
 
@@ -352,7 +391,7 @@ Response:
 }
 ```
 
-### filter_log_events [READ]
+#### filter_log_events [READ]
 
 Search log events with a pattern across log groups and streams in Amazon CloudWatch Logs.
 
@@ -413,7 +452,11 @@ Response:
 }
 ```
 
-### start_query [READ]
+### Insights Operations
+
+Insights Operations allow you to perform advanced queries and analysis on your log data using CloudWatch Logs Insights. These operations help you efficiently search and analyze log data to identify patterns and troubleshoot issues.
+
+#### start_query [READ]
 
 Start a CloudWatch Logs Insights query.
 
@@ -455,7 +498,7 @@ Response:
 }
 ```
 
-### stop_query [READ]
+#### stop_query [READ]
 
 Stop a running CloudWatch Logs Insights query.
 
@@ -487,7 +530,7 @@ Response:
 }
 ```
 
-### get_query_results [READ]
+#### get_query_results [READ]
 
 Retrieve results from a CloudWatch Logs Insights query.
 
@@ -550,7 +593,7 @@ Response:
 }
 ```
 
-### describe_queries [READ]
+#### describe_queries [READ]
 
 List and describe CloudWatch Logs Insights queries.
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -26,7 +26,7 @@ This document provides detailed information about the tools available in the Ama
 
 ### Insights Operations
 
-- [start_query](#start_query-read) - Start a insights query
+- [start_query](#start_query-read) - Start an insights query
 - [stop_query](#stop_query-read) - Stop a running insights query
 - [get_query_results](#get_query_results-read) - Retrieve query results
 - [describe_queries](#describe_queries-read) - List and describe queries

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -135,6 +135,14 @@ export const toolDefinition: ToolDefinition = {
     operationFn: insights.stopQuery,
     operationType: Operation.READ, // Classified as READ for usability
   },
+  [ToolName.GetQueryResults]: {
+    name: ToolName.GetQueryResults,
+    description: 'Retrieve the results of a CloudWatch Logs Insights query',
+    inputSchema: zodToJsonSchema(insightsSchema.GetQueryResultsRequestSchema),
+    requestSchema: insightsSchema.GetQueryResultsRequestSchema,
+    operationFn: insights.getQueryResults,
+    operationType: Operation.READ,
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for listing)

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -26,9 +26,7 @@ type ToolDefinition =
   { [N in ToolNameType]: { operationType: OperationType } }
 
 export const toolDefinition: ToolDefinition = {
-  /**
-   * Log group operations
-   */
+  // Log group operations
   [ToolName.CreateLogGroup]: {
     name: ToolName.CreateLogGroup,
     description: 'Create a new Amazon CloudWatch Logs log group',
@@ -53,9 +51,7 @@ export const toolDefinition: ToolDefinition = {
     operationFn: groups.deleteLogGroup,
     operationType: Operation.WRITE,
   },
-  /**
-   * Log stream operations
-   */
+  // Log stream operations
   [ToolName.CreateLogStream]: {
     name: ToolName.CreateLogStream,
     description: 'Create a new log stream in an Amazon CloudWatch Logs log group',
@@ -80,9 +76,7 @@ export const toolDefinition: ToolDefinition = {
     operationFn: streams.deleteLogStream,
     operationType: Operation.WRITE,
   },
-  /**
-   * Log events operations
-   */
+  // Log events operations
   [ToolName.PutLogEvents]: {
     name: ToolName.PutLogEvents,
     description: 'Write log events to a specified log stream in Amazon CloudWatch Logs',
@@ -108,24 +102,14 @@ export const toolDefinition: ToolDefinition = {
     operationFn: events.filterLogEvents,
     operationType: Operation.READ,
   },
-  /**
-   * Insights query operations
-   *
-   * Both `start_query` and `stop_query` are classified as READ:
-   * - Improved usability: Read-only users can execute and manage queries
-   * - Consistency: Query initiation and termination at the same access level
-   * - Analysis workflow: Provides complete analysis capabilities in read-only mode
-   *
-   * TODO: Consider implementing a DISABLE_TOOLS environment variable
-   * to disable the insights category when strict resource control is needed
-   */
+  // Insights query operations
   [ToolName.StartQuery]: {
     name: ToolName.StartQuery,
     description: 'Start a CloudWatch Logs Insights query',
     inputSchema: zodToJsonSchema(insightsSchema.StartQueryRequestSchema),
     requestSchema: insightsSchema.StartQueryRequestSchema,
     operationFn: insights.startQuery,
-    operationType: Operation.READ, // Classified as READ for usability
+    operationType: Operation.READ,
   },
   [ToolName.StopQuery]: {
     name: ToolName.StopQuery,
@@ -133,7 +117,7 @@ export const toolDefinition: ToolDefinition = {
     inputSchema: zodToJsonSchema(insightsSchema.StopQueryRequestSchema),
     requestSchema: insightsSchema.StopQueryRequestSchema,
     operationFn: insights.stopQuery,
-    operationType: Operation.READ, // Classified as READ for usability
+    operationType: Operation.READ,
   },
   [ToolName.GetQueryResults]: {
     name: ToolName.GetQueryResults,

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -143,6 +143,14 @@ export const toolDefinition: ToolDefinition = {
     operationFn: insights.getQueryResults,
     operationType: Operation.READ,
   },
+  [ToolName.DescribeQueries]: {
+    name: ToolName.DescribeQueries,
+    description: 'List and describe CloudWatch Logs Insights queries',
+    inputSchema: zodToJsonSchema(insightsSchema.DescribeQueriesRequestSchema),
+    requestSchema: insightsSchema.DescribeQueriesRequestSchema,
+    operationFn: insights.describeQueries,
+    operationType: Operation.READ,
+  },
 }
 
 // Available tools for Amazon CloudWatch Logs operations (for listing)

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -2,8 +2,10 @@ import { zodToJsonSchema } from 'zod-to-json-schema'
 import { config } from '../../config/index.ts'
 import * as events from '../../operations/events.ts'
 import * as groups from '../../operations/groups.ts'
+import * as insights from '../../operations/insights.ts'
 import * as eventsSchema from '../../operations/schemas/events.ts'
 import * as groupsSchema from '../../operations/schemas/groups.ts'
+import * as insightsSchema from '../../operations/schemas/insights.ts'
 import * as streamsSchema from '../../operations/schemas/streams.ts'
 import * as streams from '../../operations/streams.ts'
 import {
@@ -95,6 +97,14 @@ export const toolDefinition: ToolDefinition = {
     inputSchema: zodToJsonSchema(eventsSchema.FilterLogEventsRequestSchema),
     requestSchema: eventsSchema.FilterLogEventsRequestSchema,
     operationFn: events.filterLogEvents,
+    operationType: Operation.READ,
+  },
+  [ToolName.StartQuery]: {
+    name: ToolName.StartQuery,
+    description: 'Start a CloudWatch Logs Insights query',
+    inputSchema: zodToJsonSchema(insightsSchema.StartQueryRequestSchema),
+    requestSchema: insightsSchema.StartQueryRequestSchema,
+    operationFn: insights.startQuery,
     operationType: Operation.READ,
   },
 }

--- a/src/handlers/tools/tools.ts
+++ b/src/handlers/tools/tools.ts
@@ -26,6 +26,9 @@ type ToolDefinition =
   { [N in ToolNameType]: { operationType: OperationType } }
 
 export const toolDefinition: ToolDefinition = {
+  /**
+   * Log group operations
+   */
   [ToolName.CreateLogGroup]: {
     name: ToolName.CreateLogGroup,
     description: 'Create a new Amazon CloudWatch Logs log group',
@@ -50,6 +53,9 @@ export const toolDefinition: ToolDefinition = {
     operationFn: groups.deleteLogGroup,
     operationType: Operation.WRITE,
   },
+  /**
+   * Log stream operations
+   */
   [ToolName.CreateLogStream]: {
     name: ToolName.CreateLogStream,
     description: 'Create a new log stream in an Amazon CloudWatch Logs log group',
@@ -74,6 +80,9 @@ export const toolDefinition: ToolDefinition = {
     operationFn: streams.deleteLogStream,
     operationType: Operation.WRITE,
   },
+  /**
+   * Log events operations
+   */
   [ToolName.PutLogEvents]: {
     name: ToolName.PutLogEvents,
     description: 'Write log events to a specified log stream in Amazon CloudWatch Logs',
@@ -99,13 +108,32 @@ export const toolDefinition: ToolDefinition = {
     operationFn: events.filterLogEvents,
     operationType: Operation.READ,
   },
+  /**
+   * Insights query operations
+   *
+   * Both `start_query` and `stop_query` are classified as READ:
+   * - Improved usability: Read-only users can execute and manage queries
+   * - Consistency: Query initiation and termination at the same access level
+   * - Analysis workflow: Provides complete analysis capabilities in read-only mode
+   *
+   * TODO: Consider implementing a DISABLE_TOOLS environment variable
+   * to disable the insights category when strict resource control is needed
+   */
   [ToolName.StartQuery]: {
     name: ToolName.StartQuery,
     description: 'Start a CloudWatch Logs Insights query',
     inputSchema: zodToJsonSchema(insightsSchema.StartQueryRequestSchema),
     requestSchema: insightsSchema.StartQueryRequestSchema,
     operationFn: insights.startQuery,
-    operationType: Operation.READ,
+    operationType: Operation.READ, // Classified as READ for usability
+  },
+  [ToolName.StopQuery]: {
+    name: ToolName.StopQuery,
+    description: 'Stop a running CloudWatch Logs Insights query',
+    inputSchema: zodToJsonSchema(insightsSchema.StopQueryRequestSchema),
+    requestSchema: insightsSchema.StopQueryRequestSchema,
+    operationFn: insights.stopQuery,
+    operationType: Operation.READ, // Classified as READ for usability
   },
 }
 

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -18,6 +18,7 @@ export const ToolName = {
   StartQuery: 'start_query',
   StopQuery: 'stop_query',
   GetQueryResults: 'get_query_results',
+  DescribeQueries: 'describe_queries',
 } as const
 
 export type ToolNameType = (typeof ToolName)[keyof typeof ToolName]

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -17,6 +17,7 @@ export const ToolName = {
   FilterLogEvents: 'filter_log_events',
   StartQuery: 'start_query',
   StopQuery: 'stop_query',
+  GetQueryResults: 'get_query_results',
 } as const
 
 export type ToolNameType = (typeof ToolName)[keyof typeof ToolName]

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -15,6 +15,7 @@ export const ToolName = {
   PutLogEvents: 'put_log_events',
   GetLogEvents: 'get_log_events',
   FilterLogEvents: 'filter_log_events',
+  StartQuery: 'start_query',
 } as const
 
 export type ToolNameType = (typeof ToolName)[keyof typeof ToolName]

--- a/src/handlers/tools/types.ts
+++ b/src/handlers/tools/types.ts
@@ -16,6 +16,7 @@ export const ToolName = {
   GetLogEvents: 'get_log_events',
   FilterLogEvents: 'filter_log_events',
   StartQuery: 'start_query',
+  StopQuery: 'stop_query',
 } as const
 
 export type ToolNameType = (typeof ToolName)[keyof typeof ToolName]

--- a/src/operations/insights.ts
+++ b/src/operations/insights.ts
@@ -1,7 +1,13 @@
-import { StartQueryCommand, StopQueryCommand } from '@aws-sdk/client-cloudwatch-logs'
+import {
+  GetQueryResultsCommand,
+  StartQueryCommand,
+  StopQueryCommand,
+} from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
 import {
+  GetQueryResultsRequestSchema,
+  GetQueryResultsResponseSchema,
   StartQueryRequestSchema,
   StartQueryResponseSchema,
   StopQueryRequestSchema,
@@ -28,4 +34,15 @@ export const stopQuery = async (
   const output = await client.send(command)
 
   return StopQueryResponseSchema.parse(output)
+}
+
+export const getQueryResults = async (
+  params: z.infer<typeof GetQueryResultsRequestSchema>,
+): Promise<z.infer<typeof GetQueryResultsResponseSchema>> => {
+  const input = GetQueryResultsRequestSchema.parse(params)
+
+  const command = new GetQueryResultsCommand(input)
+  const output = await client.send(command)
+
+  return GetQueryResultsResponseSchema.parse(output)
 }

--- a/src/operations/insights.ts
+++ b/src/operations/insights.ts
@@ -1,4 +1,5 @@
 import {
+  DescribeQueriesCommand,
   GetQueryResultsCommand,
   StartQueryCommand,
   StopQueryCommand,
@@ -6,6 +7,8 @@ import {
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
 import {
+  DescribeQueriesRequestSchema,
+  DescribeQueriesResponseSchema,
   GetQueryResultsRequestSchema,
   GetQueryResultsResponseSchema,
   StartQueryRequestSchema,
@@ -45,4 +48,15 @@ export const getQueryResults = async (
   const output = await client.send(command)
 
   return GetQueryResultsResponseSchema.parse(output)
+}
+
+export const describeQueries = async (
+  params: z.infer<typeof DescribeQueriesRequestSchema>,
+): Promise<z.infer<typeof DescribeQueriesResponseSchema>> => {
+  const input = DescribeQueriesRequestSchema.parse(params)
+
+  const command = new DescribeQueriesCommand(input)
+  const output = await client.send(command)
+
+  return DescribeQueriesResponseSchema.parse(output)
 }

--- a/src/operations/insights.ts
+++ b/src/operations/insights.ts
@@ -1,0 +1,15 @@
+import { StartQueryCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { type z } from 'zod'
+import { client } from '../lib/aws/client.ts'
+import { StartQueryRequestSchema, StartQueryResponseSchema } from './schemas/insights.ts'
+
+export const startQuery = async (
+  params: z.infer<typeof StartQueryRequestSchema>,
+): Promise<z.infer<typeof StartQueryResponseSchema>> => {
+  const input = StartQueryRequestSchema.parse(params)
+
+  const command = new StartQueryCommand(input)
+  const output = await client.send(command)
+
+  return StartQueryResponseSchema.parse(output)
+}

--- a/src/operations/insights.ts
+++ b/src/operations/insights.ts
@@ -1,7 +1,12 @@
-import { StartQueryCommand } from '@aws-sdk/client-cloudwatch-logs'
+import { StartQueryCommand, StopQueryCommand } from '@aws-sdk/client-cloudwatch-logs'
 import { type z } from 'zod'
 import { client } from '../lib/aws/client.ts'
-import { StartQueryRequestSchema, StartQueryResponseSchema } from './schemas/insights.ts'
+import {
+  StartQueryRequestSchema,
+  StartQueryResponseSchema,
+  StopQueryRequestSchema,
+  StopQueryResponseSchema,
+} from './schemas/insights.ts'
 
 export const startQuery = async (
   params: z.infer<typeof StartQueryRequestSchema>,
@@ -12,4 +17,15 @@ export const startQuery = async (
   const output = await client.send(command)
 
   return StartQueryResponseSchema.parse(output)
+}
+
+export const stopQuery = async (
+  params: z.infer<typeof StopQueryRequestSchema>,
+): Promise<z.infer<typeof StopQueryResponseSchema>> => {
+  const input = StopQueryRequestSchema.parse(params)
+
+  const command = new StopQueryCommand(input)
+  const output = await client.send(command)
+
+  return StopQueryResponseSchema.parse(output)
 }

--- a/src/operations/schemas/insights.ts
+++ b/src/operations/schemas/insights.ts
@@ -1,4 +1,6 @@
 import {
+  type DescribeQueriesCommandInput,
+  type DescribeQueriesCommandOutput,
   type GetQueryResultsCommandInput,
   type GetQueryResultsCommandOutput,
   QueryLanguage,
@@ -139,5 +141,62 @@ export const GetQueryResultsResponseSchema = typeSafeSchema<
       .describe(
         "If you associated an KMS key with the CloudWatch Logs Insights query results in this account, this field displays the ARN of the key that's used to encrypt the query results when `StartQuery` stores them.",
       ),
+  }),
+)
+
+export const DescribeQueriesRequestSchema = typeSafeSchema<
+  OptionalToUndefined<DescribeQueriesCommandInput>
+>()(
+  z.object({
+    logGroupName: z
+      .string()
+      .optional()
+      .describe('Limits the returned queries to only those for the specified log group.'),
+    status: z
+      .nativeEnum(QueryStatus)
+      .optional()
+      .describe('Limits the returned queries to only those that have the specified status.'),
+    maxResults: z
+      .number()
+      .optional()
+      .describe('Limits the number of returned queries to the specified number.'),
+    nextToken: z.string().optional().describe('The token for the next set of items to return.'),
+    queryLanguage: z
+      .nativeEnum(QueryLanguage)
+      .optional()
+      .describe(
+        'Limits the returned queries to only the queries that use the specified query language.',
+      ),
+  }),
+)
+
+export const DescribeQueriesResponseSchema = typeSafeSchema<
+  OptionalToUndefined<DescribeQueriesCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    queries: z
+      .array(
+        z.object({
+          queryLanguage: z
+            .nativeEnum(QueryLanguage)
+            .optional()
+            .describe('The query language used for this query.'),
+          queryId: z.string().optional().describe('The unique ID number of this query.'),
+          queryString: z.string().optional().describe('The query string used in this query.'),
+          status: z.nativeEnum(QueryStatus).optional().describe('The status of this query.'),
+          createTime: z
+            .number()
+            .optional()
+            .describe('The date and time that this query was created.'),
+          logGroupName: z
+            .string()
+            .optional()
+            .describe('The name of the log group scanned by this query.'),
+        }),
+      )
+      .optional()
+      .describe('The list of queries that match the request.'),
+    nextToken: z.string().optional().describe('The token for the next set of items to return.'),
   }),
 )

--- a/src/operations/schemas/insights.ts
+++ b/src/operations/schemas/insights.ts
@@ -1,5 +1,8 @@
 import {
+  type GetQueryResultsCommandInput,
+  type GetQueryResultsCommandOutput,
   QueryLanguage,
+  QueryStatus,
   type StartQueryCommandInput,
   type StartQueryCommandOutput,
   type StopQueryCommandInput,
@@ -58,5 +61,83 @@ export const StopQueryResponseSchema = typeSafeSchema<
       .boolean()
       .optional()
       .describe('This is true if the query was stopped by the `StopQuery` operation.'),
+  }),
+)
+
+export const GetQueryResultsRequestSchema = typeSafeSchema<
+  OptionalToUndefined<GetQueryResultsCommandInput>
+>()(
+  z.object({
+    queryId: z.string().describe('The ID number of the query.'),
+  }),
+)
+
+export const GetQueryResultsResponseSchema = typeSafeSchema<
+  OptionalToUndefined<GetQueryResultsCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    queryLanguage: z
+      .nativeEnum(QueryLanguage)
+      .optional()
+      .describe('The query language used for this query.'),
+    results: z
+      .array(
+        z.array(
+          z.object({
+            field: z.string().optional().describe('The log event field.'),
+            value: z.string().optional().describe('The value of this field.'),
+          }),
+        ),
+      )
+      .optional()
+      .describe(
+        'The log events that matched the query criteria during the most recent time it ran.',
+      ),
+    statistics: z
+      .object({
+        recordsMatched: z
+          .number()
+          .optional()
+          .describe('The number of log events that matched the query string.'),
+        recordsScanned: z
+          .number()
+          .optional()
+          .describe('The total number of log events scanned during the query.'),
+        estimatedRecordsSkipped: z
+          .number()
+          .optional()
+          .describe(
+            'An estimate of the number of log events that were skipped when processing this query, because the query contained an indexed field.',
+          ),
+        bytesScanned: z
+          .number()
+          .optional()
+          .describe('The total number of bytes in the log events scanned during the query.'),
+        estimatedBytesSkipped: z
+          .number()
+          .optional()
+          .describe(
+            'An estimate of the number of bytes in the log events that were skipped when processing this query, because the query contained an indexed field.',
+          ),
+        logGroupsScanned: z
+          .number()
+          .optional()
+          .describe('The number of log groups that were scanned by this query.'),
+      })
+      .optional()
+      .describe(
+        'Includes the number of log events scanned by the query, the number of log events that matched the query criteria, and the total number of bytes in the scanned log events.',
+      ),
+    status: z
+      .nativeEnum(QueryStatus)
+      .optional()
+      .describe('The status of the most recent running of the query.'),
+    encryptionKey: z
+      .string()
+      .optional()
+      .describe(
+        "If you associated an KMS key with the CloudWatch Logs Insights query results in this account, this field displays the ARN of the key that's used to encrypt the query results when `StartQuery` stores them.",
+      ),
   }),
 )

--- a/src/operations/schemas/insights.ts
+++ b/src/operations/schemas/insights.ts
@@ -2,6 +2,8 @@ import {
   QueryLanguage,
   type StartQueryCommandInput,
   type StartQueryCommandOutput,
+  type StopQueryCommandInput,
+  type StopQueryCommandOutput,
 } from '@aws-sdk/client-cloudwatch-logs'
 import { z } from 'zod'
 import { typeSafeSchema } from '../../lib/zod/helper.ts'
@@ -38,5 +40,23 @@ export const StartQueryResponseSchema = typeSafeSchema<
   z.object({
     $metadata: MetadataSchema,
     queryId: z.string().optional().describe('The unique ID of the query.'),
+  }),
+)
+
+export const StopQueryRequestSchema = typeSafeSchema<OptionalToUndefined<StopQueryCommandInput>>()(
+  z.object({
+    queryId: z.string().describe('The ID number of the query to stop.'),
+  }),
+)
+
+export const StopQueryResponseSchema = typeSafeSchema<
+  OptionalToUndefined<StopQueryCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    success: z
+      .boolean()
+      .optional()
+      .describe('This is true if the query was stopped by the `StopQuery` operation.'),
   }),
 )

--- a/src/operations/schemas/insights.ts
+++ b/src/operations/schemas/insights.ts
@@ -1,0 +1,42 @@
+import {
+  QueryLanguage,
+  type StartQueryCommandInput,
+  type StartQueryCommandOutput,
+} from '@aws-sdk/client-cloudwatch-logs'
+import { z } from 'zod'
+import { typeSafeSchema } from '../../lib/zod/helper.ts'
+import { type OptionalToUndefined } from '../../types/util.ts'
+import { MetadataSchema } from './common.ts'
+
+export const StartQueryRequestSchema = typeSafeSchema<
+  OptionalToUndefined<StartQueryCommandInput>
+>()(
+  z.object({
+    queryLanguage: z
+      .nativeEnum(QueryLanguage)
+      .optional()
+      .describe('Specify the query language to use for this query.'),
+    logGroupName: z.string().optional().describe('The log group on which to perform the query.'),
+    logGroupNames: z.array(z.string()).optional().describe('The list of log groups to be queried.'),
+    logGroupIdentifiers: z
+      .array(z.string())
+      .optional()
+      .describe('The list of log groups to query.'),
+    startTime: z.number().describe('The beginning of the time range to query.'),
+    endTime: z.number().describe('The end of the time range to query.'),
+    queryString: z.string().describe('The query string to use.'),
+    limit: z
+      .number()
+      .optional()
+      .describe('The maximum number of log events to return in the query.'),
+  }),
+)
+
+export const StartQueryResponseSchema = typeSafeSchema<
+  OptionalToUndefined<StartQueryCommandOutput>
+>()(
+  z.object({
+    $metadata: MetadataSchema,
+    queryId: z.string().optional().describe('The unique ID of the query.'),
+  }),
+)


### PR DESCRIPTION
This PR adds support for CloudWatch Logs Insights query operations, enabling users to perform advanced queries and analysis on their log data.

### Features Added

- **StartQuery Tool**: Allows starting CloudWatch Logs Insights queries with support for different query languages (CWLI, PPL, SQL)
- **StopQuery Tool**: Provides the ability to stop running CloudWatch Logs Insights queries
- **GetQueryResults Tool**: Retrieves results from completed CloudWatch Logs Insights queries
- **DescribeQueries Tool**: Lists and describes CloudWatch Logs Insights queries with filtering options

### Documentation Updates

- Added detailed documentation for all new Insights tools in TOOLS.md
- Updated README.md to include the new Insights Operations section
- Reorganized TOOLS.md by operation categories for better structure and readability